### PR TITLE
Implemented handling of almost SDB

### DIFF
--- a/src/pynitefields/__init__.py
+++ b/src/pynitefields/__init__.py
@@ -1,4 +1,3 @@
 from pynitefields.galoisfield import *
 from pynitefields.fieldelement import *
 from pynitefields.pthrootofunity import *
-

--- a/src/pynitefields/fieldelement.py
+++ b/src/pynitefields/fieldelement.py
@@ -52,7 +52,7 @@ class FieldElement():
                      elements in the GaloisField this element is in.
     """
 
-    def __init__(self, p, n, exp_coefs, field_list = [], is_sdb = False, sdb_coefs = []):
+    def __init__(self, p, n, exp_coefs, field_list = [], is_sdb = False, sdb_field_list = [], sdb_coefs = []):
         self.p = p
         self.n = n
         self.dim = int(math.pow(p, n))
@@ -82,13 +82,13 @@ class FieldElement():
         # These parameters will be something other than their default value
         # only if the to_sdb function is called on the GaloisField.
         self.is_sdb = is_sdb
+        self.sdb_field_list = sdb_field_list
         self.sdb_coefs = sdb_coefs 
-      
-        # When operations are done we will also need to set the correct
-        # self-dual basis coefficients.
-        if len(self.field_list) != 0 and self.is_sdb:
-            self.sdb_coefs = field_list[prim_power].sdb_coefs
 
+        # Reset the sdb coefficients after an operation if need be.
+        if self.is_sdb:
+            self.sdb_coefs = [int(x) for x in self.sdb_field_list[self.prim_power]] 
+      
 
     def __add__(self, el):
         """ Addition.
@@ -112,7 +112,7 @@ class FieldElement():
         else: # Power of prime case
             # Coefficients simply add modulo p
             new_coefs = [(self.exp_coefs[i] + el.exp_coefs[i]) % self.p for i in range(0, self.n)]
-            return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb)
+            return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
 
 
     def __radd__(self, el):
@@ -147,7 +147,7 @@ class FieldElement():
         else:  # Power of prime case
             # Coefficients subtract modulo p
             new_coefs = [(self.exp_coefs[i] - el.exp_coefs[i]) % self.p for i in range(0, self.n)]
-            return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb)
+            return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
 
 
     def __mul__(self, el):
@@ -167,7 +167,7 @@ class FieldElement():
         """
         # Multiplication by a constant (must be on the right!)
         if isinstance(el, int):
-            return FieldElement(self.p, self.n, [(el * exp_coef) % self.p for exp_coef in self.exp_coefs] , self.field_list, self.is_sdb)
+            return FieldElement(self.p, self.n, [(el * exp_coef) % self.p for exp_coef in self.exp_coefs] , self.field_list, self.is_sdb, self.sdb_field_list)
 
         # Multiplication by another FieldElement
         elif isinstance(el, FieldElement):
@@ -187,7 +187,7 @@ class FieldElement():
                 # Multiplying by 0, nothing to see here
                 if el.prim_power == 0 or self.prim_power == 0: 
                     zeros = [0] * self.n
-                    return FieldElement(self.p, self.n, zeros, self.field_list, self.is_sdb)
+                    return FieldElement(self.p, self.n, zeros, self.field_list, self.is_sdb, self.sdb_field_list)
                 else:
                     new_exp = self.prim_power + el.prim_power # New exponent
                     # If the exponent calculated is outside the range of primitive element
@@ -196,7 +196,7 @@ class FieldElement():
                     if new_exp > self.dim - 1: 
                         new_exp = ((new_exp - 1) % (self.dim - 1)) + 1
                     new_exp_coefs = [int(x) for x in self.field_list[new_exp]] 
-                    return FieldElement(self.p, self.n, new_exp_coefs, self.field_list, self.is_sdb)
+                    return FieldElement(self.p, self.n, new_exp_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
         else:
             raise TypeError("Unsupported operator")
 
@@ -271,7 +271,7 @@ class FieldElement():
         """
         # Prime case
         if self.n == 1:
-            return FieldElement(self.p, self.n, [int(math.pow(self.prim_power, exponent)) % self.p], self.is_sdb)
+            return FieldElement(self.p, self.n, [int(math.pow(self.prim_power, exponent)) % self.p])
         # Power of prime case
         else:
             new_coefs = []
@@ -283,7 +283,7 @@ class FieldElement():
                 if new_exp > self.dim - 1:
                     new_exp = ((new_exp - 1) % (self.dim - 1)) + 1
                 new_coefs = [int(x) for x in self.field_list[new_exp]] 
-            return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb)
+            return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
             
 
     def __eq__(self, el):
@@ -369,7 +369,7 @@ class FieldElement():
 
             for i in range(0, self.p):
                 if (self.prim_power * i) % self.p == 1:
-                    return FieldElement(self.p, self.n, [i], self.is_sdb)
+                    return FieldElement(self.p, self.n, [i])
         else: # Power of prime case
             if self.prim_power == 0:
                 print("Error, 0 has no multiplicative inverse.")
@@ -380,7 +380,7 @@ class FieldElement():
             # All other elements, find exponent which sums to dim - 1
             else:
                 new_coefs = [int(x) for x in self.field_list[self.dim - self.prim_power - 1]]
-                return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb)
+                return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
 
 
     def tr(self):

--- a/src/pynitefields/fieldelement.py
+++ b/src/pynitefields/fieldelement.py
@@ -43,12 +43,14 @@ class FieldElement():
                               primitive element of the field.
             exp_coefs (list): The set of expansion coefficients of this element
                               in terms of some basis.
+            is_polyb (bool): Indicates whether this element is expressed in
+                             the polynomial basis or not.
             str_rep (string): A representation of the exp_coefs as a string.
             field_list (list of FieldElements) - A copy of the list of all 
                      elements in the GaloisField this element is in.
     """
 
-    def __init__(self, p, n, exp_coefs, field_list = []):
+    def __init__(self, p, n, exp_coefs, field_list = [], is_polyb = True):
         self.p = p
         self.n = n
         self.dim = int(math.pow(p, n))
@@ -57,6 +59,7 @@ class FieldElement():
         # If we're in a prime field, the basis is 1, and
         # the coefficient is just the value
         self.exp_coefs = exp_coefs
+        self.is_polyb = is_polyb
         self.str_rep = "".join([str(x) for x in exp_coefs])
         self.prim_power = -1
         self.field_list = []
@@ -70,6 +73,7 @@ class FieldElement():
         # ALL the field elements have been created. This is set only
         # for power of prime fields.
         if len(field_list) != 0:
+            self.poly = []
             self.field_list = field_list 
             self.prim_power = self.field_list.index(self.str_rep)
 
@@ -379,14 +383,22 @@ class FieldElement():
             Note: The trace of an element can be invoked in two ways. One can
             do el.tr() or tr(el).
         """
-        sum = self
+        s = self
 
         if self.n == 1:
             return self.prim_power
         else:
             for i in range(1, self.n):
-                sum = sum + pow(self, pow(self.p, i))
-        return sum.exp_coefs[0]
+                s = s + pow(self, pow(self.p, i))
+
+        # If we are using the self-dual basis, we need to get the "real"
+        # value of the trace from the poly basis field.
+        if not self.is_polyb:
+            from pynitefields.galoisfield import GaloisField
+            poly_f = GaloisField(self.p, self.n, self.poly)
+            s = poly_f[s.prim_power]
+
+        return s.exp_coefs[0]
 
 
     def gchar(self):

--- a/src/pynitefields/fieldelement.py
+++ b/src/pynitefields/fieldelement.py
@@ -327,12 +327,21 @@ class FieldElement():
             else:
                 return False
         else:
-            this_exp_str = [str(x) for x in self.exp_coefs]
-            that_exp_str = [str(x) for x in el.exp_coefs]
-            if "".join(this_exp_str) < "".join(that_exp_str):
-                return True
+            # If there is a sdb defined, use that, otherwise use exp_coefs
+            if self.is_sdb:
+                this_exp_str = [str(x) for x in self.sdb_coefs]
+                that_exp_str = [str(x) for x in el.sdb_coefs]
+                if "".join(this_exp_str) < "".join(that_exp_str):
+                    return True
+                else:
+                    return False
             else:
-                return False
+                this_exp_str = [str(x) for x in self.exp_coefs]
+                that_exp_str = [str(x) for x in el.exp_coefs]
+                if "".join(this_exp_str) < "".join(that_exp_str):
+                    return True
+                else:
+                    return False
 
 
     def __repr__(self):

--- a/src/pynitefields/fieldelement.py
+++ b/src/pynitefields/fieldelement.py
@@ -393,7 +393,7 @@ class FieldElement():
 
         # If we are using the self-dual basis, we need to get the "real"
         # value of the trace from the poly basis field.
-        if not self.is_polyb:
+        if self.is_polyb is False:
             from pynitefields.galoisfield import GaloisField
             poly_f = GaloisField(self.p, self.n, self.poly)
             s = poly_f[s.prim_power]

--- a/src/pynitefields/galoisfield.py
+++ b/src/pynitefields/galoisfield.py
@@ -34,10 +34,10 @@ class GaloisField():
 
             coefs (list): The coefficients of the irreducible polynomial
             elements (list): A list of all FieldElements in this finite field.
-            bool_sdb (bool): A boolean which tells us whether the elements'
-                             expansion coefficients are in the self-dual
-                             basis (True) or the polynomial basis (False). 
-                             The default is False.
+            is_sdb (bool): A boolean which tells us whether the elements'
+                           expansion coefficients are in the self-dual
+                           basis (True) or the polynomial basis (False). 
+                           The default is False.
     """
     def __init__(self, p, n = 1, coefs = []):
         # TODO implement check for prime number
@@ -118,7 +118,7 @@ class GaloisField():
                 next_coefs = [0] + self.elements[el - 1].exp_coefs
                 
                 # Get a list of the powers whose coefficients aren't 0
-                which_to_sum = [self.elements[i] * coeff for i, coeff in enumerate(next_coefs) if coeff != 0]
+                which_to_sum = [self.elements[i] * co for i, co in enumerate(next_coefs) if co != 0]
                 sum = self.elements[0]
 
                 for sum_el in which_to_sum:
@@ -136,13 +136,14 @@ class GaloisField():
             # This is really dumb, but make sure each element holds a copy of the whole
             # list of the field elements. This makes field multiplication way easier.
             for i in range(len(self.elements)):
-                (self.elements[i]).poly = coefs
                 (self.elements[i]).field_list = field_list 
                 (self.elements[i]).prim_power = i
 
-        # By default, we are using the polynomial basis
-        self.is_sdb = False
-        self.sdb_coefs = []
+        # SDB information
+        self.is_sdb = False # Have we indicated an sdb?
+        self.sdb = [] # The indices of the elements that make up the sdb
+        self.sdb_norms = [] # The trace of the sdb squared - usually 1, but
+                            # if the sdb is almost sd, then one is not 1.
 
 
     def __getitem__(self, idx):
@@ -195,37 +196,43 @@ class GaloisField():
 
         # Make sure that the provided sdb is valid. In qudit cases, we may
         # also be shuffling the elements, so make sure to get the shuffled copy.
-        valid_sdb, sdb_element_indices = self.verify_sdb(sdb_element_indices)
+        valid_sdb, valid_element_indices valid_sdb_norms = self.verify_sdb(sdb_element_indices)
 
-        if self.verify_sdb(sdb_element_indices) == False:
+        if not valid_sdb:
             print("Invalid self-dual basis provided.")
             return
+
+        if valid_element_indices != sdb_element_indices:
+            print("The order of your self-dual basis elements has changed.")
+            print("This is due to the presence of a non-1 normalization coefficient.")
+            print("New ordering is " + str(valid_element_indices) + ".")
+
+        # Set the sdb 
+        self.is_sdb = True
+        self.sdb = sdb_element_indices
+        self.sdb_norms = valid_sdb_norms
+
 
         # If all goes well, we can start computing the coefficients
         # in terms of the new elements by using the trace and multiplication
         # functions.
-        new_elements = []
-        field_list = []
-
-        sdb = [self.elements[sdb_element_indices[i]] for i in range(0, self.n)]
-
+        sdb_els = [self.elements[sdb_element_indices[i]] for i in range(0, self.n)]
+        sdb_field_list = []
         for element in self.elements:
             sdb_coefs = [] # Expansion coefficients in the sdb
 
-            for basis_el in sdb:
+            for basis_el in sdb_els:
                 sdb_coefs.append(tr(element * basis_el))
 
-            new_elements.append(FieldElement(self.p, self.n, sdb_coefs))
-            field_list.append("".join([str(x) for x in sdb_coefs]))
+            sdb_field_list.append("".join([str(x) for x in sdb_coefs]))
 
-        self.elements = new_elements
-        for i in range(len(self.elements)):
-            (self.elements[i]).field_list = field_list 
-            (self.elements[i]).prim_power = i
-            (self.elements[i]).poly = self.coefs
-            (self.elements[i]).is_polyb = False
+            element.is_sdb = True
+            element.sdb_coefs = sdb_coefs
 
-        self.is_sdb = True
+        # Finally, give every element a copy of the sdb coefficients
+        for element in self.elements:
+            element.sdb_field_list = sdb_field_list
+    
 
 
     def verify_sdb(self, sdb_element_indices):
@@ -244,14 +251,21 @@ class GaloisField():
             also reorder the almost sdb in this case so that the non-1 element is first.
  
             Returns:
-                True if above conditions are satisfied, false if not. Also returns the
-                sdb element indices, the ordering of which may change in the odd prime case.
-                Also sets the value of the class variable sdb_coefs.
+                A triple containing the following values:
+                - True if above conditions are satisfied, false if not. 
+                - The sdb element indices, the ordering of which may change if 
+                  the basis is not perfectly self-dual. None if cond 1 is false.
+                - The normalizations of the sdb elements. A list of 1s if the
+                  basis is perfectly self-dual, or a positive coefficient plus
+                  the rest of the list 1s if almost self-dual. None if cond 1
+                  is not satisfied.
         """
 
         if len(sdb_element_indices) != self.n:
             print("Error, incorrect number of elements in proposed basis.")
-            return False
+            return False, None, None
+
+        sdb_norms = []
 
         if self.p == 2: # Qubit case
             for i in range(0, self.n):
@@ -260,17 +274,15 @@ class GaloisField():
 
                     if i == j: # Same element, should have trace 1
                         if trace_result != 1:
-                            return False
+                            return False, None, None
                     else: # Different elements should be orthogonal and have trace 0
                         if trace_result != 0:
-                            return False
+                            return False, None, None
 
             # If successful, set the orthogonality coefficients to 1
-            self.sdb_coefs = [1] * self.n
+            sdb_norms = [1] * self.n
 
         else: # Qudit case
-            normalizations = []
-
             for i in range(0, self.n):
                 for j in range(0, self.n):
                     trace_result = tr(self.elements[sdb_element_indices[i]] * self.elements[sdb_element_indices[j]])
@@ -278,44 +290,42 @@ class GaloisField():
                     if i == j: # Square the element and trace it
                         # Just needs to be in the prime_field
                         if trace_result < 0 or trace_result >= self.p:
-                            return False
+                            return False, None, None
                            
                         # Only one element can have a non-1 normalization 
                         if trace_result == 1: 
-                            normalizations.append(trace_result)
+                            sdb_norms.append(trace_result)
                         else:
-                            non1 = [x for x in normalizations if x != 1]
+                            non1 = [x for x in sdb_norms if x != 1]
                             if len(non1) >= 1:
                                 print("Error, more than one element has a non-one normalization coefficient.")
                                 print("Self-dual basis is invalid.")
-                                return False            
+                                return False, None, None
                             else:
-                                normalizations.append(trace_result)
+                                sdb_norms.append(trace_result)
                     else: # Different elements must be trace-orthogonal
                         if trace_result != 0:
-                            return False
+                            return False, None, None
 
             # For power of primes, the self-dual basis **might** be real (e.g. dim 27).
             # It's possible that all normalizations are 1, so check this, and carry on if true.
-            if normalizations.count(1) == len(normalizations):
-                self.sdb_coefs = normalizations
-            else:
+            if normalizations.count(1) != len(sdb_norms):
                 # If the sdb so far has been okay, let's reshuffle it so the element
                 # with coefficient > 1 is at the beginning. I'm honestly not sure why we 
                 # do this, but this is what Andrei said to do in our LS paper.
                 # Get the index of the non-1 element. Thanks to 
                 # http://stackoverflow.com/questions/4111412/how-do-i-get-a-list-of-indices-of-non-zero-elements-in-a-list
                 non1 = [i for i, e in enumerate(normalizations) if e != 1][0] 
+
                 shuffled_sdb = [sdb_element_indices[non1]] + sdb_element_indices[:non1] + \
                                     sdb_element_indices[non1 + 1:]
-
-                # Set coefs for the whole class
-                self.sdb_coefs = [normalizations[non1]] + normalizations[:non1] + normalizations[non1 + 1:]
+                shuffled_norms = [sdb_norms[non1]] + sdb_norms[:non1] + sdb_norms[non1 + 1:]
 
                 sdb_element_indices = shuffled_sdb
+                sdb_norms = shuffled_norms
                               
         # If we made it this far, we're golden.
-        return True, sdb_element_indices
+        return True, sdb_element_indices, sdb_norms
 
 
     def compute_sdb(self):
@@ -350,14 +360,12 @@ class GaloisField():
 
 
     def to_poly(self):
-        """ Transform the expansions coefficients to the polynomial basis.
-            I'm lazy, so just return a fresh field.
-
-            .. warning::
-
-                I don't think this works.
+        """ Switch back to representation in the polynomial basis. 
         """
-        self = GaloisField(self.p, self.n, self.coefs)
+        for el in self.elements:
+            el.is_sdb = False
+            el.sdb_coefs = []
+        self.is_sdb = False
 
 
     def evaluate(self, coefs, argument):
@@ -420,12 +428,12 @@ class GaloisField():
             # include the coefficient c_1. So print a message to show this.
             if self.p != 2:
                 if self.is_sdb:
-                    if self.sdb_coefs.count(1) != len(self.sdb_coefs):
+                    if self.sdb_norms.count(1) != len(self.sdb_norms):
                         print()
                         print("The coefficients below must take into account the ", end="")
                         print("normalization of the almost self-dual basis.")
                         print("To get the proper expression, the first coefficient must always be ", end="")
-                        print("multiplied by the inverse of: " + str(self.sdb_coefs[0]))
+                        print("multiplied by the inverse of: " + str(self.sdb_norms[0]))
 
         print("\nField elements:")
         for element in self.elements:

--- a/src/pynitefields/galoisfield.py
+++ b/src/pynitefields/galoisfield.py
@@ -209,7 +209,7 @@ class GaloisField():
 
         # Set the sdb 
         self.is_sdb = True
-        self.sdb = sdb_element_indices
+        self.sdb = valid_element_indices
         self.sdb_norms = valid_sdb_norms
 
 
@@ -309,13 +309,13 @@ class GaloisField():
 
             # For power of primes, the self-dual basis **might** be real (e.g. dim 27).
             # It's possible that all normalizations are 1, so check this, and carry on if true.
-            if normalizations.count(1) != len(sdb_norms):
+            if sdb_norms.count(1) != len(sdb_norms):
                 # If the sdb so far has been okay, let's reshuffle it so the element
                 # with coefficient > 1 is at the beginning. I'm honestly not sure why we 
                 # do this, but this is what Andrei said to do in our LS paper.
                 # Get the index of the non-1 element. Thanks to 
                 # http://stackoverflow.com/questions/4111412/how-do-i-get-a-list-of-indices-of-non-zero-elements-in-a-list
-                non1 = [i for i, e in enumerate(normalizations) if e != 1][0] 
+                non1 = [i for i, e in enumerate(sdb_norms) if e != 1][0] 
 
                 shuffled_sdb = [sdb_element_indices[non1]] + sdb_element_indices[:non1] + \
                                     sdb_element_indices[non1 + 1:]

--- a/src/pynitefields/galoisfield.py
+++ b/src/pynitefields/galoisfield.py
@@ -216,7 +216,7 @@ class GaloisField():
         # If all goes well, we can start computing the coefficients
         # in terms of the new elements by using the trace and multiplication
         # functions.
-        sdb_els = [self.elements[sdb_element_indices[i]] for i in range(0, self.n)]
+        sdb_els = [self.elements[self.sdb[i]] for i in range(0, self.n)]
         sdb_field_list = []
         for element in self.elements:
             sdb_coefs = [] # Expansion coefficients in the sdb

--- a/src/pynitefields/galoisfield.py
+++ b/src/pynitefields/galoisfield.py
@@ -196,7 +196,7 @@ class GaloisField():
 
         # Make sure that the provided sdb is valid. In qudit cases, we may
         # also be shuffling the elements, so make sure to get the shuffled copy.
-        valid_sdb, valid_element_indices valid_sdb_norms = self.verify_sdb(sdb_element_indices)
+        valid_sdb, valid_element_indices, valid_sdb_norms = self.verify_sdb(sdb_element_indices)
 
         if not valid_sdb:
             print("Invalid self-dual basis provided.")

--- a/src/pynitefields/pthrootofunity.py
+++ b/src/pynitefields/pthrootofunity.py
@@ -106,7 +106,7 @@ class pthRootOfUnity():
                 :math:`\omega_p^{e \cdot ex}`, where :math:`ex` is
                 the exponent passed in as an argument.
         """
-        new_exp = (self.e * exponent) % self.p
+        new_exp = (self.e * ex) % self.p
         return pthRootOfUnity(self.p, new_exp)  
 
             


### PR DESCRIPTION
It might not be perfect, but it seems to work so far. The SDB implementation had in general become very hairy, and things like traces of products were no longer working as they were supposed to. I've fixed up how the SDB and almost-SDB are handled - now they are more like a representation for printing, rather than before where we would completely switch the expansions over to the SDB. This way it is also easy to switch back to a representation in the polynomial basis.