### PR TITLE
Fix sdb

### DIFF
--- a/src/pynitefields/fieldelement.py
+++ b/src/pynitefields/fieldelement.py
@@ -61,7 +61,7 @@ class FieldElement():
         # If we're in a prime field, the basis is 1, and
         # the coefficient is just the value
         self.exp_coefs = exp_coefs
-        self.str_rep = "".join([str(x) for x in exp_coefs])
+        self.str_rep = ",".join([str(x) for x in exp_coefs])
 
         # These parameters initially gets set by the GaloisField constructor 
         # after ALL the field elements have been created. This is set only
@@ -87,7 +87,7 @@ class FieldElement():
 
         # Reset the sdb coefficients after an operation if need be.
         if self.is_sdb:
-            self.sdb_coefs = [int(x) for x in self.sdb_field_list[self.prim_power]] 
+            self.sdb_coefs = [int(x) for x in self.sdb_field_list[self.prim_power].split(',')] 
       
 
     def __add__(self, el):
@@ -195,7 +195,7 @@ class FieldElement():
                     # the last field element is 1.
                     if new_exp > self.dim - 1: 
                         new_exp = ((new_exp - 1) % (self.dim - 1)) + 1
-                    new_exp_coefs = [int(x) for x in self.field_list[new_exp]] 
+                    new_exp_coefs = [int(x) for x in self.field_list[new_exp].split(',')] 
                     return FieldElement(self.p, self.n, new_exp_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
         else:
             raise TypeError("Unsupported operator")
@@ -277,12 +277,12 @@ class FieldElement():
             new_coefs = []
             # 0, and any element to the 0 is 0 by convention 
             if self.prim_power == 0 or exponent == 0: 
-                new_coefs = [int(x) for x in self.field_list[0]]
+                new_coefs = [int(x) for x in self.field_list[0].split(',')]
             else:
                 new_exp = self.prim_power * exponent
                 if new_exp > self.dim - 1:
                     new_exp = ((new_exp - 1) % (self.dim - 1)) + 1
-                new_coefs = [int(x) for x in self.field_list[new_exp]] 
+                new_coefs = [int(x) for x in self.field_list[new_exp].split(',')] 
             return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
             
 
@@ -388,7 +388,7 @@ class FieldElement():
                 return self 
             # All other elements, find exponent which sums to dim - 1
             else:
-                new_coefs = [int(x) for x in self.field_list[self.dim - self.prim_power - 1]]
+                new_coefs = [int(x) for x in self.field_list[self.dim - self.prim_power - 1].split(',')]
                 return FieldElement(self.p, self.n, new_coefs, self.field_list, self.is_sdb, self.sdb_field_list)
 
 

--- a/src/pynitefields/galoisfield.py
+++ b/src/pynitefields/galoisfield.py
@@ -212,6 +212,12 @@ class GaloisField():
         self.sdb = valid_element_indices
         self.sdb_norms = valid_sdb_norms
 
+        first_norm_inverse = 1  
+
+        if self.p % 2 == 1 and self.n % 2 == 0: # If p odd, n even
+            for i in range(self.p):
+                if (self.sdb_norms[0] * i) % self.p == 1:
+                    first_norm_inverse = i
 
         # If all goes well, we can start computing the coefficients
         # in terms of the new elements by using the trace and multiplication
@@ -221,8 +227,12 @@ class GaloisField():
         for element in self.elements:
             sdb_coefs = [] # Expansion coefficients in the sdb
 
-            for basis_el in sdb_els:
-                sdb_coefs.append(tr(element * basis_el))
+            for i in range(len(sdb_els)):
+                if i == 0:
+                    sdb_coefs.append((first_norm_inverse * tr(element * sdb_els[i])) % self.p)
+                else:
+                    sdb_coefs.append(tr(element * sdb_els[i]))
+
 
             sdb_field_list.append("".join([str(x) for x in sdb_coefs]))
 
@@ -423,17 +433,6 @@ class GaloisField():
 
                     if i != len(self.coefs) - 1: 
                         print(" + ", end = "")
-
-            # For almost self-dual basis, the full expansion needs to 
-            # include the coefficient c_1. So print a message to show this.
-            if self.p != 2:
-                if self.is_sdb:
-                    if self.sdb_norms.count(1) != len(self.sdb_norms):
-                        print()
-                        print("The coefficients below must take into account the ", end="")
-                        print("normalization of the almost self-dual basis.")
-                        print("To get the proper expression, the first coefficient must always be ", end="")
-                        print("multiplied by the inverse of: " + str(self.sdb_norms[0]))
 
         print("\nField elements:")
         for element in self.elements:

--- a/src/pynitefields/galoisfield.py
+++ b/src/pynitefields/galoisfield.py
@@ -97,18 +97,18 @@ class GaloisField():
             # The first element is always 0
             self.elements = []
             self.elements.append(FieldElement(self.p, self.n, [0]*self.n))
-            field_list.append("0" * self.n)
+            field_list.append("0," * (self.n - 1) + "0")
 
             # The next few elements are initial terms in the poly basis (i.e. x, x^2 ...)
             for i in range(1, self.n):
                 next_coefs = [0]*(i) + [1] + [0]*(self.n - i - 1) 
                 self.elements.append(FieldElement(self.p, self.n, next_coefs))
-                field_list.append("".join([str(x) for x in next_coefs]))
+                field_list.append(",".join([str(x) for x in next_coefs]))
 
             # For the n^th power of x, we need to use the irreducible polynomial
             nth_coefs = [((-1) * self.coefs[i]) % self.p for i in range(0, self.n)]
             self.elements.append(FieldElement(self.p, self.n, nth_coefs))
-            field_list.append("".join([str(x) for x in nth_coefs]))
+            field_list.append(",".join([str(x) for x in nth_coefs]))
 
             # For the remaining powers, multiply the previous element by primitive element
             for el in range(self.n + 1, self.dim):
@@ -126,7 +126,7 @@ class GaloisField():
 
                 # TODO Make sure that this element is not already in the list - if it is, then
                 # we did not use a true primitive polynomial.
-                str_rep = "".join([str(x) for x in sum.exp_coefs])
+                str_rep = ",".join([str(x) for x in sum.exp_coefs])
                 if str_rep not in field_list:
                     self.elements.append(sum)
                     field_list.append(str_rep)
@@ -234,7 +234,7 @@ class GaloisField():
                     sdb_coefs.append(tr(element * sdb_els[i]))
 
 
-            sdb_field_list.append("".join([str(x) for x in sdb_coefs]))
+            sdb_field_list.append(",".join([str(x) for x in sdb_coefs]))
 
             element.is_sdb = True
             element.sdb_coefs = sdb_coefs


### PR DESCRIPTION
Reimplementation of the almost-SDB complete. Expansion coefficients are now the "proper" ones. Furthermore, fixed a bug where for larger fields (i.e. p >= 11), multiplication wasn't working correctly because the expansion coefficients had double digits and this broke the handling of the field_list variable (I made the field_list strings comma delimited to take care of this).